### PR TITLE
Supabase Edge Functions client

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build": "concurrently -m 8 'npm:build:*'",
     "build:base": "rollup -c",
     "build:zod": "rollup -c --config-zod",
+    "build:supabase-edge": "rollup -c --config-supabase-edge",
     "prepublishOnly": "npm run build",
     "lint": "eslint src/**",
     "pack": "npm pack --dry-run"

--- a/src/core/typedFetch.ts
+++ b/src/core/typedFetch.ts
@@ -1,45 +1,5 @@
-import { ContentType, FetchResponse, ResponseBody, TypedFetch } from "./types";
-import { handleErrorBody, queryParser, resolveReqHeaders } from "./utils";
-
-const handleResBody = async (res: Response, contentType: ContentType) => {
-  switch (contentType) {
-    case "plain":
-      return await res.text();
-    case "html":
-      return await res.text();
-    case "json":
-      return await res.json();
-    case "noContent":
-      return;
-    default:
-      throw new Error("Response body type is inacceptable");
-  }
-};
-
-const resolveReturnValue = async <Data extends ResponseBody>(
-  res: Response,
-  contentType: ContentType
-): Promise<FetchResponse<Data>> => {
-  if (res.ok) {
-    const body = await handleResBody(res, contentType);
-    return {
-      data: body,
-      error: null,
-      status: res.status,
-      statusText: res.statusText,
-      headers: res.headers,
-    };
-  } else {
-    const body = await handleErrorBody(res);
-    return {
-      data: null,
-      error: { message: body },
-      status: res.status,
-      statusText: res.statusText,
-      headers: res.headers,
-    };
-  }
-};
+import { TypedFetch } from "./types";
+import { queryParser, resolveReqHeaders, handleReturnValue } from "./utils";
 
 /** An wrapper of the Web Fetch API. Provides `get`, `post`, `put`, `patch` and `delete` functions. */
 export const typedFetch: TypedFetch = {
@@ -48,7 +8,7 @@ export const typedFetch: TypedFetch = {
     const query = queryParser(config?.query ?? {});
     const res = await fetch(`${url}${query}`, { headers, method: "GET" });
     const contentType = config?.contentType ?? "json";
-    return resolveReturnValue(res, contentType);
+    return handleReturnValue(res, contentType);
   },
 
   post: async (url, config) => {
@@ -60,7 +20,7 @@ export const typedFetch: TypedFetch = {
       body: config?.body ? JSON.stringify(config.body) : undefined,
     });
     const contentType = config?.contentType ?? "json";
-    return resolveReturnValue(res, contentType);
+    return handleReturnValue(res, contentType);
   },
 
   put: async (url, config) => {
@@ -71,7 +31,7 @@ export const typedFetch: TypedFetch = {
       method: "PUT",
       body: config?.body ? JSON.stringify(config.body) : undefined,
     });
-    return resolveReturnValue(res, "noContent");
+    return handleReturnValue(res, "noContent");
   },
 
   patch: async (url, config) => {
@@ -83,7 +43,7 @@ export const typedFetch: TypedFetch = {
       body: config?.body ? JSON.stringify(config.body) : undefined,
     });
     const contentType = config?.contentType ?? "json";
-    return resolveReturnValue(res, contentType);
+    return handleReturnValue(res, contentType);
   },
 
   delete: async (url, config) => {
@@ -95,6 +55,6 @@ export const typedFetch: TypedFetch = {
       body: config?.body ? JSON.stringify(config.body) : undefined,
     });
     const contentType = config?.contentType ?? "noContent";
-    return resolveReturnValue(res, contentType);
+    return handleReturnValue(res, contentType);
   },
 };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -64,17 +64,17 @@ export type TypedFetch = {
 };
 
 // get type
-export type GetRequst = [url: string, config?: Omit<FetchConfig, "body">];
+export type GetRequest = [url: string, config?: Omit<FetchConfig, "body">];
 
 export type GetFunction = <Data extends ResponseBody>(
-  ...args: GetRequst
+  ...request: GetRequest
 ) => Promise<FetchResponse<Data>>;
 
 // post type
 export type PostRequest = [url: string, config?: FetchConfig];
 
 export type PostFunction = <Data extends ResponseBody>(
-  ...args: PostRequest
+  ...request: PostRequest
 ) => Promise<FetchResponse<Data>>;
 
 // put type
@@ -84,19 +84,19 @@ export type PutRequest = [
 ];
 
 export type PutFunction = (
-  ...args: PutRequest
+  ...request: PutRequest
 ) => Promise<FetchResponse<undefined>>;
 
 // patch type
 export type PatchRequest = [url: string, config?: FetchConfig];
 
 export type PatchFunction = <Data extends ResponseBody>(
-  ...args: PatchRequest
+  ...request: PatchRequest
 ) => Promise<FetchResponse<Data>>;
 
 // delete type
 export type DeleteRequest = [url: string, config?: FetchConfig];
 
 export type DeleteFunction = <Data extends ResponseBody = undefined>(
-  ...args: DeleteRequest
+  ...request: DeleteRequest
 ) => Promise<FetchResponse<Data>>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
 export { typedFetch } from "./core/typedFetch";
 export * from "./core/types";
-export { handleErrorBody, queryParser, resolveReqHeaders } from "./core/utils";
+export {
+  handleErrorBody,
+  queryParser,
+  resolveReqHeaders,
+  handleReturnValue,
+} from "./core/utils";

--- a/src/supabase-edge.ts
+++ b/src/supabase-edge.ts
@@ -1,0 +1,2 @@
+export { sefClient } from "./supabase-edge/client";
+export * from "./supabase-edge/types";

--- a/src/supabase-edge/client.ts
+++ b/src/supabase-edge/client.ts
@@ -1,0 +1,57 @@
+import { FetchHeaders, typedFetch } from "@darthrommy/fetches";
+import { SEFClient } from "./types";
+
+/** add `authorization` header. Overrides your own `authorization`. */
+const addAuthHeader = (
+  authorization: string,
+  baseHeader: FetchHeaders = {}
+): FetchHeaders => {
+  return { ...baseHeader, authorization };
+};
+
+/** client of `@darthrommy/fetches/supabase`. BTW **sef** stands for ***S**upabase **E**dge **F**unctions*. */
+export const sefClient: SEFClient = ({ referenceId, apiKey }) => {
+  const authorization = `Bearer ${apiKey}` as const;
+  const baseUrl = `https://${referenceId}.functions.supabase.co` as const;
+  return {
+    get: async (endpoint, config) => {
+      const headers = addAuthHeader(authorization, config?.headers);
+      return typedFetch.get(`${baseUrl}${endpoint}`, {
+        ...config,
+        headers,
+      });
+    },
+
+    post: async (endpoint, config) => {
+      const headers = addAuthHeader(authorization, config?.headers);
+      return typedFetch.post(`${baseUrl}${endpoint}`, {
+        ...config,
+        headers,
+      });
+    },
+
+    put: async (endpoint, config) => {
+      const headers = addAuthHeader(authorization, config?.headers);
+      return typedFetch.put(`${baseUrl}${endpoint}`, {
+        ...config,
+        headers,
+      });
+    },
+
+    patch: async (endpoint, config) => {
+      const headers = addAuthHeader(authorization, config?.headers);
+      return typedFetch.patch(`${baseUrl}${endpoint}`, {
+        ...config,
+        headers,
+      });
+    },
+
+    delete: async (endpoint, config) => {
+      const headers = addAuthHeader(authorization, config?.headers);
+      return typedFetch.delete(`${baseUrl}${endpoint}`, {
+        ...config,
+        headers,
+      });
+    },
+  };
+};

--- a/src/supabase-edge/client.ts
+++ b/src/supabase-edge/client.ts
@@ -9,7 +9,9 @@ const addAuthHeader = (
   return { ...baseHeader, authorization };
 };
 
-/** client of `@darthrommy/fetches/supabase`. BTW **sef** stands for ***S**upabase **E**dge **F**unctions*. */
+/** client of `@darthrommy/fetches/supabase`. BTW **sef** stands for ***S**upabase **E**dge **F**unctions*.
+ * @see https://rommy-docs.pages.dev/docs/fetches/supabase
+ */
 export const sefClient: SEFClient = ({ referenceId, apiKey }) => {
   const authorization = `Bearer ${apiKey}` as const;
   const baseUrl = `https://${referenceId}.functions.supabase.co` as const;

--- a/src/supabase-edge/types.ts
+++ b/src/supabase-edge/types.ts
@@ -1,9 +1,11 @@
 import {
-  DeleteFunction,
-  GetFunction,
-  PatchFunction,
-  PostFunction,
-  PutFunction,
+  DeleteRequest,
+  FetchResponse,
+  GetRequest,
+  PatchRequest,
+  PostRequest,
+  PutRequest,
+  ResponseBody,
 } from "@darthrommy/fetches";
 
 export type ClientArgs = {
@@ -21,17 +23,43 @@ export type SEFClient = (config: ClientArgs) => {
   /** `PUT` to your supabase functions. */
   put: SPPutFunction;
   /** `PATCH` your supabase functions. */
-  patch: PatchFunction;
+  patch: SPPatchFunction;
   /** `DELETE` your supabase functions. (don't worry! it won't actually delete your functions!) */
-  delete: DeleteFunction;
+  delete: SPDeleteFunction;
 };
 
-export type SPGetFunction = GetFunction;
+export type SPGetRequest = [endpoint: PostRequest[0], config?: GetRequest[1]];
 
-export type SPPostFunction = PostFunction;
+export type SPGetFunction = <Data extends ResponseBody>(
+  ...request: SPGetRequest
+) => Promise<FetchResponse<Data>>;
 
-export type SPPutFunction = PutFunction;
+export type SPPostRequest = [endpoint: PostRequest[0], config?: PostRequest[1]];
 
-export type SPPatchFunction = PatchFunction;
+export type SPPostFunction = <Data extends ResponseBody>(
+  ...request: SPPostRequest
+) => Promise<FetchResponse<Data>>;
 
-export type SPDeleteFunction = DeleteFunction;
+export type SPPutRequest = [endpoint: PutRequest[0], config?: PutRequest[1]];
+
+export type SPPutFunction = (
+  ...request: SPPutRequest
+) => Promise<FetchResponse<undefined>>;
+
+export type SPPatchRequest = [
+  endpoint: PatchRequest[0],
+  config?: PatchRequest[1]
+];
+
+export type SPPatchFunction = <Data extends ResponseBody>(
+  ...request: SPPatchRequest
+) => Promise<FetchResponse<Data>>;
+
+export type SPDeleteRequest = [
+  endpoint: DeleteRequest[0],
+  config?: DeleteRequest[1]
+];
+
+export type SPDeleteFunction = <Data extends ResponseBody = undefined>(
+  ...request: SPDeleteRequest
+) => Promise<FetchResponse<Data>>;

--- a/src/supabase-edge/types.ts
+++ b/src/supabase-edge/types.ts
@@ -1,0 +1,37 @@
+import {
+  DeleteFunction,
+  GetFunction,
+  PatchFunction,
+  PostFunction,
+  PutFunction,
+} from "@darthrommy/fetches";
+
+export type ClientArgs = {
+  /** A reference ID of your supabase project. `xxx` in `https://xxx.supabase.co` */
+  referenceId: string;
+  /** Either anon/service role key of your project. */
+  apiKey: string;
+};
+
+export type SEFClient = (config: ClientArgs) => {
+  /** `GET` from your supabase functions. */
+  get: SPGetFunction;
+  /** `POST` to your supabase functions. */
+  post: SPPostFunction;
+  /** `PUT` to your supabase functions. */
+  put: SPPutFunction;
+  /** `PATCH` your supabase functions. */
+  patch: PatchFunction;
+  /** `DELETE` your supabase functions. (don't worry! it won't actually delete your functions!) */
+  delete: DeleteFunction;
+};
+
+export type SPGetFunction = GetFunction;
+
+export type SPPostFunction = PostFunction;
+
+export type SPPutFunction = PutFunction;
+
+export type SPPatchFunction = PatchFunction;
+
+export type SPDeleteFunction = DeleteFunction;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
       "@darthrommy/fetches/*": ["./src/*.ts"]
     },
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
## Summary

`@supabase/supabase-js` actually has method to invoke Edge Functions, `client.functions.invoke`.

However, looking into its source code, it only can `POST` the endpoint, even though the other HTTP methods are now available on Edge Functions.

Then why not make my own client?