### PR TITLE
Support custom fetch

### DIFF
--- a/src/core/typedFetch.ts
+++ b/src/core/typedFetch.ts
@@ -1,32 +1,41 @@
 import { TypedFetch } from "./types";
-import { queryParser, resolveReqHeaders, handleReturnValue } from "./utils";
+import {
+  queryParser,
+  resolveReqHeaders,
+  handleReturnValue,
+  customFetch,
+} from "./utils";
 
 /** An wrapper of the Web Fetch API. Provides `get`, `post`, `put`, `patch` and `delete` functions. */
 export const typedFetch: TypedFetch = {
   get: async (url, config) => {
     const headers = resolveReqHeaders({ ...config });
     const query = queryParser(config?.query ?? {});
-    const res = await fetch(`${url}${query}`, { headers, method: "GET" });
-    const contentType = config?.contentType ?? "json";
-    return handleReturnValue(res, contentType);
+    const fetcher = customFetch(config?.customFetch);
+    const res = await fetcher(`${url}${query}`, {
+      headers,
+      method: "GET",
+    });
+    return handleReturnValue(res, config?.contentType ?? "json");
   },
 
   post: async (url, config) => {
     const headers = resolveReqHeaders({ ...config });
     const query = queryParser(config?.query ?? {});
-    const res = await fetch(`${url}${query}`, {
+    const fetcher = customFetch(config?.customFetch);
+    const res = await fetcher(`${url}${query}`, {
       headers,
       method: "POST",
       body: config?.body ? JSON.stringify(config.body) : undefined,
     });
-    const contentType = config?.contentType ?? "json";
-    return handleReturnValue(res, contentType);
+    return handleReturnValue(res, config?.contentType ?? "json");
   },
 
   put: async (url, config) => {
     const headers = resolveReqHeaders({ ...config });
     const query = queryParser(config?.query ?? {});
-    const res = await fetch(`${url}${query}`, {
+    const fetcher = customFetch(config?.customFetch);
+    const res = await fetcher(`${url}${query}`, {
       headers,
       method: "PUT",
       body: config?.body ? JSON.stringify(config.body) : undefined,
@@ -37,24 +46,24 @@ export const typedFetch: TypedFetch = {
   patch: async (url, config) => {
     const headers = resolveReqHeaders({ ...config });
     const query = queryParser(config?.query ?? {});
-    const res = await fetch(`${url}${query}`, {
+    const fetcher = customFetch(config?.customFetch);
+    const res = await fetcher(`${url}${query}`, {
       headers,
       method: "PATCH",
       body: config?.body ? JSON.stringify(config.body) : undefined,
     });
-    const contentType = config?.contentType ?? "json";
-    return handleReturnValue(res, contentType);
+    return handleReturnValue(res, config?.contentType ?? "json");
   },
 
   delete: async (url, config) => {
     const headers = resolveReqHeaders({ ...config });
     const query = queryParser(config?.query ?? {});
-    const res = await fetch(`${url}${query}`, {
+    const fetcher = customFetch(config?.customFetch);
+    const res = await fetcher(`${url}${query}`, {
       headers,
       method: "DELETE",
       body: config?.body ? JSON.stringify(config.body) : undefined,
     });
-    const contentType = config?.contentType ?? "noContent";
-    return handleReturnValue(res, contentType);
+    return handleReturnValue(res, config?.contentType ?? "noContent");
   },
 };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -7,6 +7,9 @@ export type Json = Record<
   string | number | boolean | null | { [key: string]: Json } | Json[]
 >;
 
+/** fetch type */
+export type Fetch = typeof fetch;
+
 /** query type */
 export type Query = Record<string, string>;
 
@@ -41,6 +44,7 @@ export type FetchConfig = {
   query?: Query;
   body?: Json;
   contentType?: ContentType;
+  customFetch?: typeof fetch;
 };
 
 /** `typedFetch` interface */

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,5 +1,6 @@
 import {
   ContentType,
+  Fetch,
   FetchHeaders,
   FetchResponse,
   Json,
@@ -75,4 +76,8 @@ export const handleReturnValue = async <Data extends ResponseBody>(
       headers: res.headers,
     };
   }
+};
+
+export const customFetch = (method: Fetch = fetch) => {
+  return method;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,5 @@ export {
   queryParser,
   resolveReqHeaders,
   handleReturnValue,
+  customFetch,
 } from "./core/utils";

--- a/src/supabase-edge/client.ts
+++ b/src/supabase-edge/client.ts
@@ -12,14 +12,15 @@ const addAuthHeader = (
 /** client of `@darthrommy/fetches/supabase`. BTW **sef** stands for ***S**upabase **E**dge **F**unctions*.
  * @see https://rommy-docs.pages.dev/docs/fetches/supabase
  */
-export const sefClient: SEFClient = ({ referenceId, apiKey }) => {
+export const sefClient: SEFClient = ({ referenceId, apiKey, customFetch }) => {
   const authorization = `Bearer ${apiKey}` as const;
   const baseUrl = `https://${referenceId}.functions.supabase.co` as const;
   return {
     get: async (endpoint, config) => {
       const headers = addAuthHeader(authorization, config?.headers);
       return typedFetch.get(`${baseUrl}${endpoint}`, {
-        ...config,
+        customFetch,
+        ...config, // overwrite global customFetch
         headers,
       });
     },
@@ -27,6 +28,7 @@ export const sefClient: SEFClient = ({ referenceId, apiKey }) => {
     post: async (endpoint, config) => {
       const headers = addAuthHeader(authorization, config?.headers);
       return typedFetch.post(`${baseUrl}${endpoint}`, {
+        customFetch,
         ...config,
         headers,
       });
@@ -35,6 +37,7 @@ export const sefClient: SEFClient = ({ referenceId, apiKey }) => {
     put: async (endpoint, config) => {
       const headers = addAuthHeader(authorization, config?.headers);
       return typedFetch.put(`${baseUrl}${endpoint}`, {
+        customFetch,
         ...config,
         headers,
       });
@@ -43,6 +46,7 @@ export const sefClient: SEFClient = ({ referenceId, apiKey }) => {
     patch: async (endpoint, config) => {
       const headers = addAuthHeader(authorization, config?.headers);
       return typedFetch.patch(`${baseUrl}${endpoint}`, {
+        customFetch,
         ...config,
         headers,
       });
@@ -51,6 +55,7 @@ export const sefClient: SEFClient = ({ referenceId, apiKey }) => {
     delete: async (endpoint, config) => {
       const headers = addAuthHeader(authorization, config?.headers);
       return typedFetch.delete(`${baseUrl}${endpoint}`, {
+        customFetch,
         ...config,
         headers,
       });

--- a/src/supabase-edge/types.ts
+++ b/src/supabase-edge/types.ts
@@ -1,5 +1,6 @@
 import {
   DeleteRequest,
+  Fetch,
   FetchResponse,
   GetRequest,
   PatchRequest,
@@ -13,6 +14,10 @@ export type ClientArgs = {
   referenceId: string;
   /** Either anon/service role key of your project. */
   apiKey: string;
+  /** Globally defines custom fetch client. Can be alternative fetches like `cross-fetch` and `node-fetch`.
+   *  You can also configure in each method overwriting this configuration.
+   */
+  customFetch?: Fetch;
 };
 
 export type SEFClient = (config: ClientArgs) => {

--- a/src/zod/types.ts
+++ b/src/zod/types.ts
@@ -1,7 +1,9 @@
 import {
-  FetchConfig,
   FetchData,
   FetchResponse,
+  GetRequest,
+  PatchRequest,
+  PostRequest,
   ResponseBody,
 } from "@darthrommy/fetches";
 import { z } from "zod";
@@ -32,8 +34,8 @@ export type ZFError = {
 
 // GET
 export type ZGetRequest<Schema extends ObjectSchema> = [
-  url: string,
-  config: Omit<FetchConfig, "body"> & {
+  url: GetRequest[0],
+  config: GetRequest[1] & {
     schema: Schema;
   }
 ];
@@ -44,8 +46,8 @@ export type ZGetFunction = <Schema extends ObjectSchema>(
 
 // POST
 export type ZPostRequest<Schema extends ObjectSchema> = [
-  url: string,
-  config: FetchConfig & { schema: Schema }
+  url: PostRequest[0],
+  config: PostRequest[1] & { schema: Schema }
 ];
 
 export type ZPostFunction = <Schema extends ObjectSchema>(
@@ -54,8 +56,8 @@ export type ZPostFunction = <Schema extends ObjectSchema>(
 
 // PATCH
 export type ZPatchRequest<Schema extends ObjectSchema> = [
-  url: string,
-  config: FetchConfig & { schema: Schema }
+  url: PatchRequest[0],
+  config: PatchRequest[1] & { schema: Schema }
 ];
 
 export type ZPatchFunction = <Schema extends ObjectSchema>(

--- a/src/zod/zodFetch.ts
+++ b/src/zod/zodFetch.ts
@@ -2,6 +2,7 @@ import {
   handleErrorBody,
   queryParser,
   resolveReqHeaders,
+  customFetch,
 } from "@darthrommy/fetches";
 import { z } from "zod";
 import { ZFResponse, ZodFetch } from "./types";
@@ -59,14 +60,19 @@ export const zodFetch: ZodFetch = {
   get: async (url, config) => {
     const headers = resolveReqHeaders({ ...config });
     const query = queryParser(config.query ?? {});
-    const res = await fetch(`${url}${query}`, { method: "GET", headers });
+    const fetcher = customFetch(config.customFetch);
+    const res = await fetcher(`${url}${query}`, {
+      method: "GET",
+      headers,
+    });
     return handleReturnValue(res, config.schema);
   },
 
   post: async (url, config) => {
     const headers = resolveReqHeaders({ ...config });
     const query = queryParser(config.query ?? {});
-    const res = await fetch(`${url}${query}`, {
+    const fetcher = customFetch(config.customFetch);
+    const res = await fetcher(`${url}${query}`, {
       method: "POST",
       headers,
       body: config.body ? JSON.stringify(config.body) : undefined,
@@ -77,7 +83,8 @@ export const zodFetch: ZodFetch = {
   patch: async (url, config) => {
     const headers = resolveReqHeaders({ ...config });
     const query = queryParser(config.query ?? {});
-    const res = await fetch(`${url}${query}`, {
+    const fetcher = customFetch(config.customFetch);
+    const res = await fetcher(`${url}${query}`, {
       method: "POST",
       headers,
       body: config.body ? JSON.stringify(config.body) : undefined,


### PR DESCRIPTION
Since not all JS/TS environments globally declares `fetch`, the fetch client has to be customizable by users.